### PR TITLE
Bundle id case sensitive fix

### DIFF
--- a/Source/Application/Configurations/Zhip.xcconfig
+++ b/Source/Application/Configurations/Zhip.xcconfig
@@ -3,7 +3,7 @@
 
 SDKROOT = iphoneos
 
-PRODUCT_BUNDLE_IDENTIFIER = com.openzesame.Zhip
+PRODUCT_BUNDLE_IDENTIFIER = com.openzesame.zhip
 PRODUCT_NAME = $(_APP_NAME)
 
 LD_RUNPATH_SEARCH_PATHS = $(inherited) @executable_path/../Frameworks
@@ -16,5 +16,5 @@ ENABLE_TESTABILITY = YES
 CODE_SIGN_IDENTITY[config=Debug] = iPhone Developer
 CODE_SIGN_IDENTITY[config=Release] = iPhone Distribution
 DEVELOPMENT_TEAM = S33QJG3B86
-PROVISIONING_PROFILE_SPECIFIER[config=Debug] = match Development com.openzesame.Zhip
-PROVISIONING_PROFILE_SPECIFIER[config=Release] = match AppStore com.openzesame.Zhip
+PROVISIONING_PROFILE_SPECIFIER[config=Debug] = match Development com.openzesame.zhip
+PROVISIONING_PROFILE_SPECIFIER[config=Release] = match AppStore com.openzesame.zhip

--- a/Source/Application/GoogleService-Info.plist
+++ b/Source/Application/GoogleService-Info.plist
@@ -7,9 +7,9 @@
 	<key>AD_UNIT_ID_FOR_INTERSTITIAL_TEST</key>
 	<string>ca-app-pub-3940256099942544/4411468910</string>
 	<key>CLIENT_ID</key>
-	<string>998313904669-obkr75037m39bobn3tqjo2hcnpurpb9s.apps.googleusercontent.com</string>
+	<string>998313904669-ngte57ffdcmrflsg9qbfhvsjir7hal3i.apps.googleusercontent.com</string>
 	<key>REVERSED_CLIENT_ID</key>
-	<string>com.googleusercontent.apps.998313904669-obkr75037m39bobn3tqjo2hcnpurpb9s</string>
+	<string>com.googleusercontent.apps.998313904669-ngte57ffdcmrflsg9qbfhvsjir7hal3i</string>
 	<key>API_KEY</key>
 	<string>AIzaSyDZbHClFJVgzm4WrzGznLhVu_10NugSaMg</string>
 	<key>GCM_SENDER_ID</key>
@@ -17,7 +17,7 @@
 	<key>PLIST_VERSION</key>
 	<string>1</string>
 	<key>BUNDLE_ID</key>
-	<string>com.openzesame.Zhip</string>
+	<string>com.openzesame.zhip</string>
 	<key>PROJECT_ID</key>
 	<string>zhip-d910f</string>
 	<key>STORAGE_BUCKET</key>
@@ -33,7 +33,7 @@
 	<key>IS_SIGNIN_ENABLED</key>
 	<false/>
 	<key>GOOGLE_APP_ID</key>
-	<string>1:998313904669:ios:ee46f1b9008a1d69</string>
+	<string>1:998313904669:ios:ca8166c415ba0220</string>
 	<key>DATABASE_URL</key>
 	<string>https://zhip-d910f.firebaseio.com</string>
 </dict>

--- a/fastlane/Appfile
+++ b/fastlane/Appfile
@@ -1,4 +1,4 @@
-app_identifier("com.openzesame.Zhip") # The bundle identifier of your app
+app_identifier("com.openzesame.zhip") # The bundle identifier of your app
 
 itc_team_id("119963635") # App Store Connect Team ID
 team_id("S33QJG3B86") # Developer Portal Team ID

--- a/fastlane/Matchfile
+++ b/fastlane/Matchfile
@@ -2,4 +2,4 @@
 
 type("appstore") # The default type, can be: appstore, adhoc, enterprise or development
 
-app_identifier("com.openzesame.Zhip")
+app_identifier("com.openzesame.zhip")


### PR DESCRIPTION
<!-- Thanks for contributing to _Zhip_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec fastlane tests` from the root directory to see all new and existing tests pass
- [x] I've followed the _Zhip_ code style enforced by Swiftlint and not introduced any new warning.
- [x] I've read the [Contribution Guidelines](https://github.com/OpenZesame/Zhip/blob/develop/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Bundle identifiers are case senstive, "com.openzesame.Zhip" is incorrect, correct is "com.openzesame.zhip"

### Description
Replaced bundle id from "Zhip" with capital Z to "zhip" which is the correct in fastlane `Appfile` and `Matchfile` and GoogleService-Info plist and xcconfig files .