### PR TITLE
Update Codecov badge for Sajjon/Zhip

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![codecov](https://codecov.io/gh/OpenZesame/Zhip/graph/badge.svg?token=QXYIVYRA0P)](https://codecov.io/gh/OpenZesame/Zhip)
+[![codecov](https://codecov.io/gh/Sajjon/Zhip/graph/badge.svg?token=BPAwuG4UMT)](https://codecov.io/gh/Sajjon/Zhip)
 
 # Unmaintained
 


### PR DESCRIPTION
## Summary

Repo moved from `OpenZesame/Zhip` → `Sajjon/Zhip`. README's Codecov badge needs the new owner + new badge token, otherwise it 404s.

## Test plan

- [ ] Confirm the badge renders green (or whatever the current coverage is) once this lands on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)